### PR TITLE
Add more taxon info when converting to/from DwC

### DIFF
--- a/pyinaturalist_convert/dwc.py
+++ b/pyinaturalist_convert/dwc.py
@@ -19,15 +19,14 @@
    :functions-only:
    :nosignatures:
 """
-import re
-
 # TODO: For sound recordings: eol:dataObject.dcterms:type and any other fields?
+import re
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
 from dateutil.parser import parse as parse_date
 from flatten_dict import flatten, unflatten
-from pyinaturalist import Coordinates, Observation, Photo, get_taxa_by_id
+from pyinaturalist import RANKS, Coordinates, Observation, Photo, get_taxa_by_id
 from pyinaturalist.converters import try_float_pair, try_int
 
 from .constants import PathOrStr
@@ -45,18 +44,24 @@ OBSERVATION_FIELDS = {
     'taxon.id': 'dwc:taxonID',
     'taxon.rank': 'dwc:taxonRank',
     'taxon.name': 'dwc:scientificName',
+    'taxon.preferred_common_name': 'dwc:vernacularName',
     'taxon.kingdom': 'dwc:kingdom',
     'taxon.phylum': 'dwc:phylum',
     'taxon.class': 'dwc:class',
     'taxon.order': 'dwc:order',
     'taxon.family': 'dwc:family',
+    'taxon.subfamily': 'dwc:subfamily',
     'taxon.genus': 'dwc:genus',
+    'taxon.subgenus': 'dwc:subgenus',
+    'taxon.variety': 'dwc:cultivarEpithet',
+    'taxon.iconic_taxon_id': 'inat:iconic_taxon_id',
     'updated_at': 'dcterms:modified',
     'uri': ['dcterms:references', 'dwc:occurrenceDetails', 'dwc:occurrenceID'],
     'user.login': 'dwc:inaturalistLogin',
     'user.name': ['dwc:recordedBy', 'dcterms:rightsHolder'],
     'user.orcid': 'dwc:recordedByID',
 }
+
 
 # Fields from first ID (observation['identifications'][0])
 ID_FIELDS = {
@@ -219,7 +224,7 @@ def taxon_to_dwc_record(taxon: Dict) -> Dict:
         taxon[ancestor['rank']] = ancestor['name']
 
     return {
-        dwc_field: taxon.get(inat_field.replace('taxon.', ''))
+        dwc_field: taxon.get(inat_field.replace('taxon.', '').replace('inat.', ''))
         for inat_field, dwc_field in OBSERVATION_FIELDS.items()
         if inat_field.startswith('taxon.')
     }
@@ -316,19 +321,24 @@ def dwc_to_observations(filename: PathOrStr) -> List[Observation]:
     return [dwc_record_to_observation(record) for record in _ensure_list(records)]
 
 
-# TODO: Translate taxon ancestors, eol:dataObject
+# TODO: Translate eol:dataObject to photos
 def dwc_record_to_observation(dwc_record: Dict[str, Any]) -> Observation:
     """Translate a DwC record to an Observation object"""
     lookup = get_dwc_lookup()
 
     json_record = {json_key: dwc_record.get(dwc_key) for dwc_key, json_key in lookup.items()}
-    json_record['id'] = try_int(json_record.get('id'))
-    json_record['taxon.id'] = try_int(json_record.get('taxon.id'))
     json_record['captive'] = dwc_record.get('captive') == 'cultivated'
+    json_record['geoprivacy'] = _format_dwc_geoprivacy(dwc_record)
     json_record['license_code'] = _format_dwc_license(dwc_record)
     json_record['location'] = _format_dwc_location(dwc_record)
-    json_record['geoprivacy'] = _format_dwc_geoprivacy(dwc_record)
+    json_record['positional_accuracy'] = try_int(json_record.get('positional_accuracy'))
+    json_record['taxon.ancestors'] = _format_dwc_ancestors(dwc_record)
+    json_record['taxon.partial'] = True
 
+    for field in ['id', 'taxon.id', 'taxon.iconic_taxon_id']:
+        json_record[field] = try_int(json_record.get(field))
+    if isinstance(json_record['updated_at'], list):
+        json_record['updated_at'] = json_record['updated_at'][0]
     if isinstance(json_record['user.name'], list):
         json_record['user.name'] = json_record['user.name'][0]
     json_record = unflatten(json_record, splitter='dot')
@@ -350,6 +360,14 @@ def get_dwc_lookup() -> Dict[str, str]:
     lookup['dwc:informationWithheld'] = 'geoprivacy'
     lookup['dwc:eventDate'] = 'observed_on'
     return lookup
+
+
+def _format_dwc_ancestors(dwc_record: Dict) -> List[Dict[str, str]]:
+    ancestors = []
+    for rank in RANKS[::-1]:
+        if name := dwc_record.get(f'dwc:{rank}'):
+            ancestors.append({'rank': rank, 'name': name})
+    return ancestors
 
 
 def _format_dwc_geoprivacy(dwc_record: Dict) -> Optional[str]:

--- a/test/sample_data/observations.dwc
+++ b/test/sample_data/observations.dwc
@@ -11,12 +11,17 @@
         <dwc:taxonID>48978</dwc:taxonID>
         <dwc:taxonRank>species</dwc:taxonRank>
         <dwc:scientificName>Dirona picta</dwc:scientificName>
+        <dwc:vernacularName>Colorful Dirona</dwc:vernacularName>
         <dwc:kingdom>Animalia</dwc:kingdom>
         <dwc:phylum>Mollusca</dwc:phylum>
         <dwc:class>Gastropoda</dwc:class>
         <dwc:order>Nudibranchia</dwc:order>
         <dwc:family>Dironidae</dwc:family>
+        <dwc:subfamily></dwc:subfamily>
         <dwc:genus>Dirona</dwc:genus>
+        <dwc:subgenus></dwc:subgenus>
+        <dwc:cultivarEpithet></dwc:cultivarEpithet>
+        <inat:iconic_taxon_id>47115</inat:iconic_taxon_id>
         <dcterms:modified>2020-08-16 18:09:44-07:00</dcterms:modified>
         <dcterms:references>https://www.inaturalist.org/observations/45524803</dcterms:references>
         <dwc:occurrenceDetails>https://www.inaturalist.org/observations/45524803</dwc:occurrenceDetails>

--- a/test/test_dwc.py
+++ b/test/test_dwc.py
@@ -33,6 +33,8 @@ def test_taxon_to_dwc():
             {'rank': 'genus', 'name': 'Philemon'},
             {'rank': '', 'name': ''},
         ],
+        'iconic_taxon_id': 3,
+        'preferred_common_name': 'Helmeted Friarbird',
     }
 
     dwc_record = to_dwc(taxa=[taxon])[0]
@@ -45,7 +47,12 @@ def test_taxon_to_dwc():
         'dwc:class': 'Aves',
         'dwc:order': 'Passeriformes',
         'dwc:family': 'Meliphagidae',
+        'dwc:subfamily': None,
         'dwc:genus': 'Philemon',
+        'dwc:subgenus': None,
+        'dwc:cultivarEpithet': None,
+        'dwc:vernacularName': 'Helmeted Friarbird',
+        'inat:iconic_taxon_id': 3,
     }
 
 
@@ -61,4 +68,9 @@ def test_dwc_record_to_observation():
     assert obs.location == (32.8430971478, -117.2815829044)
     assert obs.observed_on == datetime(2020, 5, 9, 6, 1, tzinfo=tzoffset(None, -25200))
     assert obs.taxon.id == 48978
+    assert obs.taxon.iconic_taxon_id == 47115
     assert obs.taxon.name == 'Dirona picta'
+    assert obs.taxon.preferred_common_name == 'Colorful Dirona'
+    assert len(obs.taxon.ancestors) == 6
+    kingdom = obs.taxon.ancestors[0]
+    assert kingdom.name == 'Animalia' and kingdom.rank == 'kingdom'


### PR DESCRIPTION
Updates #47 

Add taxon common name, iconic taxon ID, subfamily, subgenus, and variety/cultivar to DwC records