### PR TITLE
When updating taxon record from API, don't overwrite pre-computed stats

### DIFF
--- a/pyinaturalist_convert/_models.py
+++ b/pyinaturalist_convert/_models.py
@@ -155,10 +155,10 @@ class DbTaxon:
     __sa_dataclass_metadata_key__ = 'sa'
 
     id: int = sa_field(Integer, primary_key=True)
-    active: bool = sa_field(Boolean, default=None)
     ancestor_ids: str = sa_field(String, default=None)
     child_ids: str = sa_field(String, default=None)
     iconic_taxon_id: int = sa_field(Integer, default=0)
+    is_active: bool = sa_field(Boolean, default=None)
     leaf_taxa_count: int = sa_field(Integer, default=0)
     observations_count: int = sa_field(Integer, default=0)
     name: str = sa_field(String, default=None, index=True)
@@ -174,10 +174,10 @@ class DbTaxon:
         photo_urls = _join_photo_urls(taxon.taxon_photos or [taxon.default_photo])
         return cls(
             id=taxon.id,
-            active=taxon.is_active,
             ancestor_ids=_join_list(taxon.ancestor_ids),
             child_ids=_join_list(taxon.child_ids),
             iconic_taxon_id=taxon.iconic_taxon_id,
+            is_active=taxon.is_active,
             leaf_taxa_count=taxon.complete_species_count,
             observations_count=taxon.observations_count,
             name=taxon.name,
@@ -197,7 +197,7 @@ class DbTaxon:
             children=_get_taxa(self.child_ids),
             default_photo=photos[0] if photos else None,
             iconic_taxon_id=self.iconic_taxon_id,
-            is_active=self.active,
+            is_active=self.is_active,
             complete_species_count=self.leaf_taxa_count,
             observations_count=self.observations_count,
             name=self.name,

--- a/pyinaturalist_convert/_models.py
+++ b/pyinaturalist_convert/_models.py
@@ -18,7 +18,7 @@ from pyinaturalist import (
 from sqlalchemy import Boolean, Column, Float, ForeignKey, Integer, String, inspect, types
 from sqlalchemy.orm import registry, relationship
 
-PRECOMPUTED_COLUMNS = ['leaf_taxa_count', 'observations_count']
+from .taxonomy import PRECOMPUTED_COLUMNS
 
 Base = registry()
 JsonField = Dict[str, Any]
@@ -164,6 +164,7 @@ class DbTaxon:
     is_active: bool = sa_field(Boolean, default=None)
     leaf_taxa_count: int = sa_field(Integer, default=0)
     observations_count: int = sa_field(Integer, default=0)
+    observations_count_rg: int = sa_field(Integer, default=0)
     name: str = sa_field(String, default=None, index=True)
     parent_id: int = sa_field(ForeignKey('taxon.id'), default=None, index=True)
     partial: int = sa_field(Boolean, default=False)
@@ -202,7 +203,7 @@ class DbTaxon:
             iconic_taxon_id=self.iconic_taxon_id,
             is_active=self.is_active,
             complete_species_count=self.leaf_taxa_count,
-            observations_count=self.observations_count,
+            observations_count=self.observations_count_rg or self.observations_count,
             name=self.name,
             parent_id=self.parent_id,
             partial=self.partial,

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -25,7 +25,7 @@ from pyinaturalist_convert.db import (
 def test_save_observations(tmp_path):
     db_path = tmp_path / 'observations.db'
     taxon = Taxon(id=1, name='test taxon', reference_url='https://google.com')
-    user = User(id=1, login='Test user')
+    user = User(id=1, login='test_user')
     annotation_1 = Annotation(
         term=ControlledTerm(label='term'),
         value=ControlledTermValue(label='value'),
@@ -92,6 +92,11 @@ def test_save_observations(tmp_path):
     assert obs_2.taxon.id == obs_1.taxon.id
     assert obs_2.taxon.reference_url == obs_1.taxon.reference_url
     assert obs_2.user.id == obs_1.user.id
+
+    results = get_db_observations(db_path, username='test_user', order_by_date=True)
+    assert len(list(results)) == 1
+    results = get_db_observations(db_path, username='nonexistent_user', limit=1)
+    assert len(list(results)) == 0
 
 
 def test_save_taxa(tmp_path):

--- a/test/test_taxonomy.py
+++ b/test/test_taxonomy.py
@@ -42,7 +42,7 @@ def test_aggregate_taxon_db(mock_sleep, tmp_path):
             'parent_id': 'parent_id',
             'name': 'name',
             'rank': 'rank',
-            'count': 'observations_count',
+            'count': 'observations_count_rg',
         },
     )
 
@@ -65,7 +65,7 @@ def test_aggregate_taxon_db(mock_sleep, tmp_path):
     with sqlite3.connect(db_path) as conn:
         conn.row_factory = sqlite3.Row
         actual_observation_counts = {
-            row['id']: row['observations_count']
+            row['id']: row['observations_count_rg']
             for row in conn.execute('SELECT * FROM taxon').fetchall()
         }
         actual_leaf_taxon_counts = {


### PR DESCRIPTION
Closes #97

Other SQLite db changes:
* Add username filter and order_by_date option to `get_db_observations()`
* Rename db column `Taxon.active` to `is_active` for consistency with API results